### PR TITLE
Added @ to location of CLI (@aws-amplify/cli)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ npm install
 2. Copy your `aws-exports` file into the src directory, or intialize a new [AWS Amplify CLI](https://github.com/aws-amplify/amplify-cli) project:
 
 ```bash
-$ npm install -g aws-amplify/cli
+$ npm install -g @aws-amplify/cli
 
 $ amplify init
 


### PR DESCRIPTION
Fails without this change.

See docs at https://github.com/aws-amplify/amplify-cli

*Issue #, if available:*

*Description of changes:*
Simple change of README to correct location of amplify-cli

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
